### PR TITLE
pengeprat: redesign oppsummering, legg til feiring-side og reset-knapp

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,9 @@
     {
       "name": "pengeprat",
       "runtimeExecutable": "npx",
-      "runtimeArgs": ["serve", ".", "-p", "4321"],
-      "port": 4321
+      "runtimeArgs": ["serve", "."],
+      "port": 4321,
+      "autoPort": true
     }
   ]
 }

--- a/pengeprat/index.html
+++ b/pengeprat/index.html
@@ -66,6 +66,10 @@
 
         <div id="oversikt-kort" class="project-list"></div>
 
+        <div style="margin-top: var(--space-3); text-align: right;">
+          <button id="tilbakestill-knapp" class="hidden">↩ Tilbakestill til forslaget</button>
+        </div>
+
         <div class="result-card" style="margin-top: var(--space-5);">
           <div class="result-row">
             <span class="result-label">Total</span>
@@ -214,33 +218,50 @@
       <section id="oppsummering" class="view">
         <h1>Din plan er klar</h1>
 
-        <div class="result-card" style="margin-bottom: var(--space-6);">
-          <div class="result-row">
-            <span class="result-label">Månedslønn</span>
-            <span id="oppsummering-lønn" class="result-value accent"></span>
-          </div>
-        </div>
-
-        <div id="oppsummering-poster" class="result-card" style="margin-bottom: var(--space-6);"></div>
+        <h3 style="margin-bottom: var(--space-3);">Neste steg: sett opp faste overføringer</h3>
+        <p style="margin-bottom: var(--space-4);">Legg inn automatiske trekk i nettbanken 2–3 dager etter lønningsdagen:</p>
 
         <div class="result-card" style="margin-bottom: var(--space-6);">
-          <h3 style="margin-bottom: var(--space-4);">Neste steg: sett opp faste overføringer</h3>
-          <p style="margin-bottom: var(--space-4);">
-            Legg inn automatiske trekk i nettbanken 2–3 dager etter lønningsdagen:
-          </p>
+          <p class="label-small" style="margin-bottom: var(--space-4);">Dine faste trekk</p>
           <div id="oppsummering-overføringer"></div>
         </div>
 
-        <div class="button-row">
-          <button id="kopier-knapp" class="primary">
-            Kopier til utklippstavle
-          </button>
-          <span id="kopiert-melding" class="kopiert-melding">✓ Kopiert!</span>
+        <p id="oppsummering-kontekst-tekst" style="margin-bottom: var(--space-4); margin-top: var(--space-6);"></p>
+        <p style="margin-bottom: var(--space-2);">Ser det bra ut, eller er det noe du trenger å justere?</p>
+        <div style="display: flex; gap: var(--space-3); align-items: flex-start; flex-wrap: wrap; margin-bottom: var(--space-6);">
+          <button id="tilbake-til-oversikt-knapp" style="color: var(--text);">← Gå tilbake til oversikt</button>
+          <div id="bekreft-wrapper">
+            <button id="bekreft-knapp-1" class="primary">Ferdig, har satt opp de faste trekkene</button>
+            <div id="bekreft-steg-2" class="hidden" style="margin-top: var(--space-5);">
+              <p style="margin-bottom: var(--space-4);">Er du sikker på at du har gjort alt du skal? Hvis ikke fortjener du ikke det som kommer.</p>
+              <button id="bekreft-knapp-2" class="primary">Ja, jeg er klar!</button>
+            </div>
+          </div>
         </div>
 
-        <div style="display: flex; gap: var(--space-3); align-items: center; margin-bottom: var(--space-5);">
-          <button id="tilbake-til-oversikt-knapp">← Tilbake til oversikt</button>
-          <button id="start-på-nytt-knapp" class="danger">Start på nytt</button>
+      </section>
+
+      <section id="feiring" class="view">
+        <p style="margin-bottom: var(--space-5);">
+          <button id="feiring-tilbake-knapp" style="color: var(--text-muted);">← Planen din</button>
+        </p>
+
+        <h1>Du er god!</h1>
+
+        <p style="margin-bottom: var(--space-6);">
+          Å sette opp automatiske trekk er en av de viktigste tingene du kan gjøre for sparingen din.
+          Nå skjer det av seg selv — uten at du trenger å tenke på det.
+        </p>
+
+        <h3 style="margin-bottom: var(--space-3);">Vil du spare mer?</h3>
+        <p class="text-muted" style="margin-bottom: var(--space-6);">
+          Test ut planen din en måned først, og se over de faste utgiftene dine
+          om det er noe du kan kutte ut eller justere på. Det er bedre å starte litt rolig enn
+          for aggressivt.
+        </p>
+
+        <div style="margin-bottom: var(--space-6);">
+          <a href="../" class="primary">Gå til alle verktøyene</a>
         </div>
 
         <div class="privacy-notice">

--- a/pengeprat/js/main.js
+++ b/pengeprat/js/main.js
@@ -33,6 +33,7 @@ const el = {
   oversiktTotal: document.getElementById('oversikt-total'),
   endreLønnKnapp: document.getElementById('endre-lønn-knapp'),
   seOppsummeringKnapp: document.getElementById('se-oppsummering-knapp'),
+  tilbakestillKnapp: document.getElementById('tilbakestill-knapp'),
 
   // Detalj
   detaljTilbakeKnapp: document.getElementById('detalj-tilbake-knapp'),
@@ -71,13 +72,16 @@ const el = {
   detaljLagreKnapp: document.getElementById('detalj-lagre-knapp'),
 
   // Oppsummering
-  oppsummeringLønn: document.getElementById('oppsummering-lønn'),
-  oppsummeringPoster: document.getElementById('oppsummering-poster'),
   oppsummeringOverføringer: document.getElementById('oppsummering-overføringer'),
-  kopierKnapp: document.getElementById('kopier-knapp'),
-  koptertMelding: document.getElementById('kopiert-melding'),
+  oppsummeringKontekstTekst: document.getElementById('oppsummering-kontekst-tekst'),
   tilbakeTilOversiktKnapp: document.getElementById('tilbake-til-oversikt-knapp'),
-  startPåNyttKnapp: document.getElementById('start-på-nytt-knapp'),
+  bekreftWrapper: document.getElementById('bekreft-wrapper'),
+  bekreftKnapp1: document.getElementById('bekreft-knapp-1'),
+  bekreftSteg2: document.getElementById('bekreft-steg-2'),
+  bekreftKnapp2: document.getElementById('bekreft-knapp-2'),
+
+  // Feiring
+  feiringTilbakeKnapp: document.getElementById('feiring-tilbake-knapp'),
 };
 
 // ─── Inngang: event listeners ────────────────────────────────────────────────
@@ -137,6 +141,18 @@ el.oversiktKort.addEventListener('click', (e) => {
   if (kort) åpneDetalj(kort.dataset.postId);
 });
 
+el.tilbakestillKnapp.addEventListener('click', () => {
+  const fordeling = beregnStandardfordeling(state.lønn);
+  for (const [key, beløp] of Object.entries(fordeling)) {
+    state.poster[key].månedlig = beløp;
+  }
+  for (const key of Object.keys(state.interaksjon)) {
+    state.interaksjon[key] = false;
+  }
+  lagreState();
+  rendreOversikt();
+});
+
 // ─── Detalj: event listeners ─────────────────────────────────────────────────
 
 el.detaljTilbakeKnapp.addEventListener('click', gåTilOversikt);
@@ -188,26 +204,24 @@ el.detaljMålInput.addEventListener('input', () => {
 
 // ─── Oppsummering: event listeners ───────────────────────────────────────────
 
-el.kopierKnapp.addEventListener('click', async () => {
-  const tekst = byggKopierTekst();
-  try {
-    await navigator.clipboard.writeText(tekst);
-    el.koptertMelding.classList.add('synlig');
-    setTimeout(() => el.koptertMelding.classList.remove('synlig'), 2500);
-  } catch (e) {
-    // Fallback: prompt bruker til å kopiere manuelt
-    prompt('Kopier planen din:', tekst);
-  }
-});
-
 el.tilbakeTilOversiktKnapp.addEventListener('click', gåTilOversikt);
 
-el.startPåNyttKnapp.addEventListener('click', () => {
-  tilbakestillState();
-  el.lønnInput.value = '';
-  el.startKnapp.disabled = true;
-  visView('inngang');
-  el.lønnInput.focus();
+el.bekreftKnapp1.addEventListener('click', () => {
+  el.bekreftKnapp1.classList.add('hidden');
+  el.bekreftSteg2.classList.remove('hidden');
+});
+
+el.bekreftKnapp2.addEventListener('click', async () => {
+  const { default: confetti } = await import('https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.module.mjs');
+  confetti({ particleCount: 120, spread: 70, origin: { y: 0.6 } });
+  setTimeout(() => confetti({ particleCount: 80, angle: 60, spread: 55, origin: { x: 0 } }), 250);
+  setTimeout(() => confetti({ particleCount: 80, angle: 120, spread: 55, origin: { x: 1 } }), 400);
+  setTimeout(() => visView('feiring'), 1200);
+});
+
+el.feiringTilbakeKnapp.addEventListener('click', () => {
+  rendreOppsummering();
+  visView('oppsummering');
 });
 
 // ─── Navigasjon ───────────────────────────────────────────────────────────────
@@ -246,6 +260,14 @@ function rendreOversikt() {
       </div>
     `;
   }).join('');
+
+  // Vis/skjul tilbakestill-knapp
+  const harEndringer = Object.values(state.interaksjon).some((v) => v);
+  if (harEndringer) {
+    el.tilbakestillKnapp.classList.remove('hidden');
+  } else {
+    el.tilbakestillKnapp.classList.add('hidden');
+  }
 }
 
 // ─── Render: Detalj ───────────────────────────────────────────────────────────
@@ -355,32 +377,19 @@ function oppdaterDetaljVisning() {
 // ─── Render: Oppsummering ─────────────────────────────────────────────────────
 
 function rendreOppsummering() {
-  el.oppsummeringLønn.textContent = formatKr(state.lønn);
-
-  // Poster-liste
-  el.oppsummeringPoster.innerHTML = KATEGORIER.map((kat) => {
-    const beløp = state.poster[kat.id]?.månedlig ?? 0;
-    return `
-      <div class="result-row">
-        <span class="result-label">
-          <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${kat.farge};margin-right:8px;vertical-align:middle;"></span>
-          ${kat.navn}
-        </span>
-        <span class="result-value">${formatKr(beløp)}/mnd</span>
-      </div>
-    `;
-  }).join('');
-
   // Neste steg: bare spareposter og pensjon
   const overføringsPoster = KATEGORIER.filter((k) =>
-    ['buffer', 'ferie', 'storeLivshendelser', 'pensjon'].includes(k.id)
+    ['buffer', 'guiltFree', 'ferie', 'storeLivshendelser', 'pensjon'].includes(k.id)
   );
 
   el.oppsummeringOverføringer.innerHTML = overføringsPoster
     .map((kat) => {
       const beløp = state.poster[kat.id]?.månedlig ?? 0;
       if (beløp === 0) return '';
-      const kontoType = kat.id === 'pensjon' ? 'IPS (pensjonssparing)' : 'sparekonto';
+      const kontoType =
+        kat.id === 'pensjon' ? 'IPS (pensjonssparing)' :
+        kat.id === 'guiltFree' ? 'forbrukskonto' :
+        'sparekonto';
       return `
         <div class="result-row">
           <span class="result-label">→ ${kat.navn}</span>
@@ -389,6 +398,23 @@ function rendreOppsummering() {
       `;
     })
     .join('');
+
+  // Tilbakestill bekreft-seksjonen
+  el.bekreftKnapp1.classList.remove('hidden');
+  el.bekreftSteg2.classList.add('hidden');
+  if (!el.bekreftWrapper.contains(el.bekreftKnapp1)) {
+    el.bekreftWrapper.innerHTML = '';
+    el.bekreftWrapper.appendChild(el.bekreftKnapp1);
+    el.bekreftWrapper.appendChild(el.bekreftSteg2);
+  }
+
+  // Kontekstuell oppsummeringstekst
+  const lønn = formatKr(state.lønn);
+  const faste = formatKr(state.poster.fasteUtgifter.månedlig);
+  const guiltFree = formatKr(state.poster.guiltFree.månedlig);
+  el.oppsummeringKontekstTekst.textContent =
+    `Dette er basert på at månedslønnen din er ${lønn}, at du har ${faste} i faste utgifter, ` +
+    `og at du bruker ${guiltFree} til hygge og livets opphold den måneden.`;
 }
 
 function byggKopierTekst() {
@@ -406,7 +432,7 @@ function byggKopierTekst() {
     ``,
     `Neste steg: sett opp faste overføringer i nettbanken`,
     ...KATEGORIER.filter((k) =>
-      ['buffer', 'ferie', 'storeLivshendelser', 'pensjon'].includes(k.id)
+      ['buffer', 'guiltFree', 'ferie', 'storeLivshendelser', 'pensjon'].includes(k.id)
     )
       .filter((kat) => (state.poster[kat.id]?.månedlig ?? 0) > 0)
       .map((kat) => {

--- a/pengeprat/style.css
+++ b/pengeprat/style.css
@@ -286,7 +286,8 @@ input[type="range"]::-moz-range-thumb {
 
 /* ─── Buttons ─── */
 
-button {
+button,
+a.primary {
   font-family: var(--font);
   font-size: 0.75rem;
   cursor: pointer;
@@ -297,6 +298,8 @@ button {
   padding: var(--space-2) var(--space-4);
   letter-spacing: 0.03em;
   transition: border-color 0.15s, color 0.15s, background 0.15s;
+  text-decoration: none;
+  display: inline-block;
 }
 
 button:hover {
@@ -309,7 +312,8 @@ button:disabled {
   cursor: not-allowed;
 }
 
-button.primary {
+button.primary,
+a.primary {
   background: var(--accent-dim);
   border-color: var(--accent-dim);
   color: #fff;
@@ -317,7 +321,8 @@ button.primary {
   font-size: 0.8rem;
 }
 
-button.primary:hover:not(:disabled) {
+button.primary:hover:not(:disabled),
+a.primary:hover {
   background: var(--accent);
   border-color: var(--accent);
 }


### PR DESCRIPTION
## Sammendrag

- **Redesign av «Din plan er klar»**: «Neste steg: sett opp faste overføringer» er flyttet øverst og er nå primærfokus på siden. Redundant lønn/kategorioversikt er fjernet.
- **To-stegs bekreftelse med konfetti**: Ny bekreftelseflyt med «Ferdig, har satt opp de faste trekkene» → bekreftelsesprompt → konfetti (canvas-confetti) → navigasjon til feiring-siden.
- **Ny #feiring-side**: Siden brukeren lander på etter fullføring — med skryt, «Vil du spare mer?»-seksjon, breadcrumb tilbake til planen og primary-knapp til alle verktøy.
- **Reset-knapp på oversikt**: «↩ Tilbakestill til forslaget» vises kun etter at brukeren har gjort manuelle endringer.
- **Guilt-free spending i overføringslisten**: Vises med kontoType «forbrukskonto».
- **`a.primary` i CSS**: Lenker kan nå styles som primary-knapper uten å måtte bytte til `<button>`.

## Testplan

- [ ] Skriv inn lønn → start → oversikt vises
- [ ] Rediger en kategori → «↩ Tilbakestill til forslaget» dukker opp → klikk → verdier tilbakestilles, knapp forsvinner
- [ ] Klikk «Se oppsummering» → «Neste steg»-seksjon øverst, ingen lønn/kategoriliste
- [ ] Klikk «Ferdig, har satt opp de faste trekkene» → bekreftelsesprompt vises
- [ ] Klikk «Ja, jeg er klar!» → konfetti → etter ~1.2s navigeres til «Du er god!»-siden
- [ ] Klikk «← Planen din» → tilbake til oppsummering med reset bekreftelsesknapper
- [ ] Klikk «Gå til alle verktøyene» → navigerer til rotsiden (`../`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)