### PR TITLE
fix: replace text arrows with Phosphor icons in button components

### DIFF
--- a/src/components/fordeling/FasteTrekk.tsx
+++ b/src/components/fordeling/FasteTrekk.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { ArrowLeftIcon, ArrowRightIcon } from "@phosphor-icons/react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Separator } from "@/components/ui/separator"
@@ -127,10 +128,12 @@ export function FasteTrekk({
         {/* Action buttons */}
         <div className="flex flex-col-reverse sm:flex-row sm:justify-between gap-3">
           <Button variant="outline" onClick={onTilbake}>
-            ← Tilbake til fordeling
+            <ArrowLeftIcon data-icon="inline-start" /> Tilbake til fordeling
           </Button>
           <Button disabled={!alleHuketAv} onClick={onFullført}>
-            {alleHuketAv ? "Ferdig! →" : "Gå videre"}
+            {alleHuketAv ? (
+              <>Ferdig! <ArrowRightIcon data-icon="inline-end" /></>
+            ) : "Gå videre"}
           </Button>
         </div>
 

--- a/src/components/fordeling/Feiring.tsx
+++ b/src/components/fordeling/Feiring.tsx
@@ -1,3 +1,4 @@
+import { ArrowLeftIcon } from "@phosphor-icons/react"
 import { Button } from "@/components/ui/button"
 
 interface FeiringProps {
@@ -29,13 +30,14 @@ export function Feiring({ onTilbakeTilPlan }: FeiringProps) {
         </div>
 
         <div className="flex flex-col gap-2">
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={onTilbakeTilPlan}
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground"
           >
-            &larr; Tilbake til planen
-          </button>
+            <ArrowLeftIcon data-icon="inline-start" /> Tilbake til planen
+          </Button>
           <Button asChild className="w-full">
             <a href={import.meta.env.BASE_URL}>Gå til alle verktøyene</a>
           </Button>

--- a/src/components/fordeling/Inngang.tsx
+++ b/src/components/fordeling/Inngang.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { ArrowRightIcon } from "@phosphor-icons/react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
@@ -59,7 +60,7 @@ export function Inngang({ onStart }: InngangProps) {
           </div>
 
           <Button onClick={handleSubmit} disabled={!gyldig} className="w-full">
-            Lag plan &rarr;
+            Lag plan <ArrowRightIcon data-icon="inline-end" />
           </Button>
 
           <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
- Swap &rarr;/&larr;/←/→ text characters for ArrowRightIcon/ArrowLeftIcon
- Use data-icon="inline-start/end" per shadcn button conventions
- Replace naked <button> in Feiring with shadcn Button variant="ghost"

Closes #21