### PR TITLE
fix: prevent sliders from taking from fasteUtgifter (#38)

### DIFF
--- a/src/hooks/useFordelingState.ts
+++ b/src/hooks/useFordelingState.ts
@@ -70,13 +70,22 @@ export function useFordelingState() {
         const poster = structuredClone(prev.poster)
 
         const gammel = poster[postId].månedlig
-        const differanse = nyVerdi - gammel
-        poster[postId].månedlig = nyVerdi
-
-        // Fordel differansen likt på andre poster (unntatt fasteUtgifter)
         const andrePoster = (Object.keys(poster) as PostId[]).filter(
           (k) => k !== postId && k !== "fasteUtgifter"
         )
+
+        // Cap the new value so the slider can only take from other adjustable posts,
+        // never from fasteUtgifter (which represents real financial obligations).
+        const sumAndrePoster = andrePoster.reduce(
+          (s, k) => s + (poster[k].månedlig ?? 0),
+          0
+        )
+        const begrensetVerdi = Math.min(nyVerdi, gammel + sumAndrePoster)
+
+        const differanse = begrensetVerdi - gammel
+        poster[postId].månedlig = begrensetVerdi
+
+        // Fordel differansen likt på andre poster (unntatt fasteUtgifter)
         fordelLikt(differanse, andrePoster, poster, prev.lønn)
 
         return {

--- a/src/lib/beregninger.ts
+++ b/src/lib/beregninger.ts
@@ -111,6 +111,7 @@ export function omfordelEtterFasteUtgifter(
 
 // Fordeler differansen likt på valgte poster.
 // Kapper negative verdier på 0 – resten håndteres av justerTilTotal.
+// fasteUtgifter holdes utenfor justeringen siden den er en reell forpliktelse.
 export function fordelLikt(
   differanse: number,
   andrePoster: PostId[],
@@ -125,14 +126,15 @@ export function fordelLikt(
     poster[k].månedlig = Math.round(ny / 50) * 50
   })
 
-  justerTilTotal(lønn, poster)
+  justerTilTotal(lønn, poster, ["fasteUtgifter"])
 }
 
-// Justerer den største posten for å absorbere avrundingsfeil slik at
-// total alltid er lik lønn.
+// Justerer den største tillatte posten for å absorbere avrundingsfeil slik at
+// total alltid er lik lønn. excludeIds angir poster som ikke skal justeres.
 export function justerTilTotal(
   lønn: number,
-  poster: Record<PostId, PostState>
+  poster: Record<PostId, PostState>,
+  excludeIds: PostId[] = []
 ): void {
   const total = Object.values(poster).reduce(
     (s, p) => s + (p.månedlig ?? 0),
@@ -141,9 +143,11 @@ export function justerTilTotal(
   const diff = lønn - total
   if (diff === 0) return
 
-  const sortert = (Object.entries(poster) as [PostId, PostState][]).sort(
-    (a, b) => (b[1].månedlig ?? 0) - (a[1].månedlig ?? 0)
-  )
+  const sortert = (Object.entries(poster) as [PostId, PostState][])
+    .filter(([k]) => !excludeIds.includes(k as PostId))
+    .sort((a, b) => (b[1].månedlig ?? 0) - (a[1].månedlig ?? 0))
+
+  if (sortert.length === 0) return
   sortert[0][1].månedlig = (sortert[0][1].månedlig ?? 0) + diff
 }
 


### PR DESCRIPTION
## Summary

- Sliders can no longer reduce faste utgifter automatically — they stop when all other adjustable posts are at zero
- `endrePost` now clamps the new value to `gammel + sumAndrePoster` before distributing
- `justerTilTotal` accepts an `excludeIds` parameter; `fordelLikt` passes `["fasteUtgifter"]` so rounding adjustments never land on faste utgifter
- Manual editing of faste utgifter via the text input is unaffected

## Test plan

- [x] Slider set far beyond available — clamped correctly, fasteUtgifter unchanged
- [x] Slider set to exact max — fasteUtgifter unchanged, total = lønn
- [x] Slider increase when one post already at 0 — fasteUtgifter unchanged
- [x] Normal slider increase and decrease — still works as before

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)