### PR TITLE
feat(landing): add Definer taket card and reorder tools

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,32 +31,6 @@ import { ArrowRight } from "@phosphor-icons/react"
         <!-- Tool cards -->
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 
-          <!-- Fordeling — aktiv -->
-          <a
-            href={`${import.meta.env.BASE_URL}/fordeling`}
-            class="group flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/30"
-          >
-            <div class="flex items-start justify-between">
-              <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                01
-              </span>
-              <span class="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
-                Tilgjengelig
-              </span>
-            </div>
-            <div class="space-y-1">
-              <h2 class="font-semibold text-foreground">Fordeling</h2>
-              <p class="text-sm text-muted-foreground leading-relaxed">
-                Finn ut hvor mye du kan spare, sett deg mål, og se hvordan du
-                kan fordele sparingen din.
-              </p>
-            </div>
-            <div class="flex items-center gap-1.5 text-sm font-medium text-primary mt-auto">
-              <span>Start</span>
-              <ArrowRight size={16} className="transition-transform group-hover:translate-x-0.5" />
-            </div>
-          </a>
-
           <!-- Månedlige utgifter — aktiv -->
           <a
             href={`${import.meta.env.BASE_URL}/utgifter`}
@@ -64,7 +38,7 @@ import { ArrowRight } from "@phosphor-icons/react"
           >
             <div class="flex items-start justify-between">
               <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                02
+                01
               </span>
               <span class="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
                 Tilgjengelig
@@ -83,11 +57,63 @@ import { ArrowRight } from "@phosphor-icons/react"
             </div>
           </a>
 
+          <!-- Fordeling — aktiv -->
+          <a
+            href={`${import.meta.env.BASE_URL}/fordeling`}
+            class="group flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/30"
+          >
+            <div class="flex items-start justify-between">
+              <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                02
+              </span>
+              <span class="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+                Tilgjengelig
+              </span>
+            </div>
+            <div class="space-y-1">
+              <h2 class="font-semibold text-foreground">Fordeling</h2>
+              <p class="text-sm text-muted-foreground leading-relaxed">
+                Finn ut hvor mye du kan spare, sett deg mål, og se hvordan du
+                kan fordele sparingen din.
+              </p>
+            </div>
+            <div class="flex items-center gap-1.5 text-sm font-medium text-primary mt-auto">
+              <span>Start</span>
+              <ArrowRight size={16} className="transition-transform group-hover:translate-x-0.5" />
+            </div>
+          </a>
+
+          <!-- Definer taket — aktiv -->
+          <a
+            href={`${import.meta.env.BASE_URL}/sparemaal`}
+            class="group flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/30"
+          >
+            <div class="flex items-start justify-between">
+              <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                03
+              </span>
+              <span class="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+                Tilgjengelig
+              </span>
+            </div>
+            <div class="space-y-1">
+              <h2 class="font-semibold text-foreground">Definer taket</h2>
+              <p class="text-sm text-muted-foreground leading-relaxed">
+                Sett en øvre grense for sparemålene dine, og finn ut når du faktisk
+                er ferdig spart.
+              </p>
+            </div>
+            <div class="flex items-center gap-1.5 text-sm font-medium text-primary mt-auto">
+              <span>Start</span>
+              <ArrowRight size={16} className="transition-transform group-hover:translate-x-0.5" />
+            </div>
+          </a>
+
           <!-- Fått inn en uventet sum — kommer snart -->
           <div class="flex flex-col gap-4 rounded-xl border border-border bg-card p-5 opacity-60">
             <div class="flex items-start justify-between">
               <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                03
+                04
               </span>
               <span class="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
                 Kommer snart


### PR DESCRIPTION
## Summary
- Adds new tool card **Definer taket** (#35)  — links to `/sparemaal` (placeholder until tool is ready)
- Reorders tool cards so Månedlige utgifter (01) comes before Fordeling (02), reflecting the logical user flow
- Bumps "Fått inn en uventet sum" from 03 → 04

## Test plan
- [ ] Visit landing page and verify card order: Månedlige utgifter → Fordeling → Definer taket → Fått inn en uventet sum
- [ ] Verify "Definer taket" shows "Tilgjengelig" badge and "Start →" link
- [ ] Verify "Fått inn en uventet sum" still shows "Kommer snart" and no link

🤖 Generated with [Claude Code](https://claude.com/claude-code)