### PR TITLE
Migrate to subdomain pengeprat.simenlager.no

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import react from "@astrojs/react"
 
 // https://astro.build/config
 export default defineConfig({
-  base: "/pengeprat",
+  site: "https://pengeprat.simenlager.no",
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/components/fordeling/Feiring.tsx
+++ b/src/components/fordeling/Feiring.tsx
@@ -39,7 +39,7 @@ export function Feiring({ onTilbakeTilPlan }: FeiringProps) {
             <ArrowLeftIcon data-icon="inline-start" /> Tilbake til planen
           </Button>
           <Button asChild className="w-full">
-            <a href={import.meta.env.BASE_URL}>Gå til alle verktøyene</a>
+            <a href="/">Gå til alle verktøyene</a>
           </Button>
         </div>
 

--- a/src/components/sparemaal/SparemaalApp.tsx
+++ b/src/components/sparemaal/SparemaalApp.tsx
@@ -186,7 +186,7 @@ export function SparemaalApp() {
     <div className="flex flex-col gap-3">
       {/* Back link */}
       <a
-        href={`${import.meta.env.BASE_URL}`}
+        href="/"
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-1"
       >
         <ArrowLeft size={15} />

--- a/src/layouts/app.astro
+++ b/src/layouts/app.astro
@@ -14,13 +14,11 @@ const {
 
 const pathname = Astro.url.pathname
 
-const base = import.meta.env.BASE_URL
-
 const verktøy = [
-  { href: `${base}/fordeling`, label: "Fordeling" },
-  { href: `${base}/utgifter`, label: "Utgifter" },
-  { href: `${base}/sparemaal`, label: "Definer taket" },
-  { href: `${base}/uventet-sum`, label: "Uventet sum" },
+  { href: "/fordeling", label: "Fordeling" },
+  { href: "/utgifter", label: "Utgifter" },
+  { href: "/sparemaal", label: "Definer taket" },
+  { href: "/uventet-sum", label: "Uventet sum" },
 ]
 
 function erAktiv(href: string) {
@@ -33,7 +31,7 @@ function erAktiv(href: string) {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{title}</title>
     <script is:inline>
       const getThemePreference = () => {
@@ -52,7 +50,7 @@ function erAktiv(href: string) {
     <header class="sticky top-0 z-10 border-b border-border bg-card">
       <div class="mx-auto flex h-14 max-w-5xl items-center justify-between px-4 sm:px-6">
         <a
-          href={import.meta.env.BASE_URL}
+          href="/"
           class="text-sm font-semibold tracking-tight text-foreground hover:text-primary transition-colors"
         >
           Pengeprat

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -17,7 +17,7 @@ const {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}/favicon.svg`} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{title}</title>
     <script is:inline>
       const getThemePreference = () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,7 +33,7 @@ import { ArrowRight } from "@phosphor-icons/react"
 
           <!-- Månedlige utgifter — aktiv -->
           <a
-            href={`${import.meta.env.BASE_URL}/utgifter`}
+            href={"/utgifter"}
             class="group flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/30"
           >
             <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -54,7 +54,7 @@ import { ArrowRight } from "@phosphor-icons/react"
 
           <!-- Fordeling — aktiv -->
           <a
-            href={`${import.meta.env.BASE_URL}/fordeling`}
+            href={"/fordeling"}
             class="group flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/30"
           >
             <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -75,7 +75,7 @@ import { ArrowRight } from "@phosphor-icons/react"
 
           <!-- Definer taket — aktiv -->
           <a
-            href={`${import.meta.env.BASE_URL}/sparemaal`}
+            href={"/sparemaal"}
             class="group flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/30"
           >
             <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -96,7 +96,7 @@ import { ArrowRight } from "@phosphor-icons/react"
 
           <!-- Uventet sum — aktiv -->
           <a
-            href={`${import.meta.env.BASE_URL}/uventet-sum`}
+            href={"/uventet-sum"}
             class="group flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/30"
           >
             <span class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
@@ -145,8 +145,8 @@ import { ArrowRight } from "@phosphor-icons/react"
           </p>
           <p class="leading-7 mt-4 text-muted-foreground">
             Planen får du ved å ta en slags pengeprat med deg selv. Skaff deg
-            en <a href={`${import.meta.env.BASE_URL}/utgifter`} class="underline decoration-muted-foreground/40 hover:text-foreground hover:decoration-foreground transition-colors">oversikt over dine faste utgifter</a>. Se over hva du har spart opp
-            fra før. <a href={`${import.meta.env.BASE_URL}/fordeling`} class="underline decoration-muted-foreground/40 hover:text-foreground hover:decoration-foreground transition-colors">Fordel pengene</a> utover spareområdene. Sett opp faste trekk
+            en <a href={"/utgifter"} class="underline decoration-muted-foreground/40 hover:text-foreground hover:decoration-foreground transition-colors">oversikt over dine faste utgifter</a>. Se over hva du har spart opp
+            fra før. <a href={"/fordeling"} class="underline decoration-muted-foreground/40 hover:text-foreground hover:decoration-foreground transition-colors">Fordel pengene</a> utover spareområdene. Sett opp faste trekk
             fra lønningskontoen som går automatisk hver måned. Og kjenn på
             følelsen av at du har kontroll, uavhengig av hvor mye du faktisk
             tjener.


### PR DESCRIPTION
## Summary
- Remove `base: "/pengeprat"` from `astro.config.mjs`, replace with `site: "https://pengeprat.simenlager.no"`
- Replace all `import.meta.env.BASE_URL` usages with plain root-relative paths (`/fordeling`, `/utgifter`, etc.)
- No more rewrite proxy needed — the app now routes directly via DNS CNAME

## Test plan
- [ ] Merge and confirm Vercel deploys clean
- [ ] Visit `pengeprat.simenlager.no` and verify homepage loads
- [ ] Click each tool card and verify nav links work