### PR TITLE
Add cursor-pointer to interactive elements in Fordeling components

### DIFF
--- a/src/components/fordeling/FordelingPanel.tsx
+++ b/src/components/fordeling/FordelingPanel.tsx
@@ -305,7 +305,7 @@ export function FordelingPanel({
         {/* Backdrop — fades in/out */}
         <div
           className={[
-            "absolute inset-0 bg-black/50 transition-opacity duration-300",
+            "absolute inset-0 bg-black/50 transition-opacity duration-300 cursor-pointer",
             activePostId ? "opacity-100" : "opacity-0",
           ].join(" ")}
           onClick={onClose}

--- a/src/components/fordeling/FordelingTabell.tsx
+++ b/src/components/fordeling/FordelingTabell.tsx
@@ -274,8 +274,8 @@ export function FordelingTabell({
               <div
                 role="row"
                 className={[
-                  "border-b border-border last:border-b-0 transition-colors",
-                  erAktiv ? "bg-muted/30" : "hover:bg-accent cursor-pointer",
+                  "border-b border-border last:border-b-0 transition-colors cursor-pointer",
+                  erAktiv ? "bg-muted/30" : "hover:bg-accent",
                 ].join(" ")}
               >
                 {/* Main row content */}


### PR DESCRIPTION
## Summary
Updated cursor styling on interactive elements in the Fordeling components to provide better visual feedback to users that these elements are clickable.

## Key Changes
- **FordelingTabell.tsx**: Moved `cursor-pointer` class from conditional hover state to always-applied base styles on the row element, ensuring the cursor indicates clickability regardless of active state
- **FordelingPanel.tsx**: Added `cursor-pointer` class to the backdrop overlay to indicate it's clickable for closing the panel

## Implementation Details
These changes improve UX by making it immediately clear that:
- Each row in the Fordeling table is interactive and clickable
- The backdrop overlay can be clicked to close the panel

The cursor styling is now consistently applied to all interactive elements, providing clearer affordance to users.

https://claude.ai/code/session_0185Crc9NHHPNSmZKNgnZAp4