### PR TITLE
Redesign Uventet sum: start fra null, avrunding til 100, pedagogisk saldovisning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 
 # Editor
 .idea/
+
+# Dependencies
+node_modules/
+
+# Astro generated files
+.astro/
+
+# Build output
+dist/

--- a/src/components/uventet-sum/UventetSumApp.tsx
+++ b/src/components/uventet-sum/UventetSumApp.tsx
@@ -1,16 +1,15 @@
 import { useRef, useState } from "react"
-import { ArrowCounterClockwiseIcon, ArrowRightIcon, LockOpenIcon, PlusIcon, TrashIcon, WarningIcon } from "@phosphor-icons/react"
+import { ArrowCounterClockwiseIcon, ArrowRightIcon, CheckCircle, PlusIcon, TrashIcon } from "@phosphor-icons/react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Slider } from "@/components/ui/slider"
 import { Separator } from "@/components/ui/separator"
-import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
 import { formatKr } from "@/lib/formatering"
 import { useUventetSumState } from "@/hooks/useUventetSumState"
 import type { UventetSumKategori } from "@/types/uventet-sum"
 
 // ---------------------------------------------------------------------------
-// Helper
+// Helpers
 // ---------------------------------------------------------------------------
 
 function parseBeløp(str: string): number {
@@ -19,72 +18,102 @@ function parseBeløp(str: string): number {
   return isNaN(tall) || tall < 0 ? 0 : tall
 }
 
+function avrundTilNærmeste100(n: number): number {
+  return Math.round(n / 100) * 100
+}
+
 // ---------------------------------------------------------------------------
 // Distribution bar
 // ---------------------------------------------------------------------------
 
 interface FordelingsBarProps {
   kategorier: UventetSumKategori[]
-  ufordeltKr: number
+  beløp: number
+  tilgjengeligKr: number
 }
 
-function FordelingsBar({ kategorier, ufordeltKr }: FordelingsBarProps) {
-  const synlige = kategorier.filter((k) => k.prosent > 0)
-  const ufordeltProsent = 100 - kategorier.reduce((s, k) => s + k.prosent, 0)
+function FordelingsBar({ kategorier, beløp, tilgjengeligKr }: FordelingsBarProps) {
+  const synlige = kategorier.filter((k) => k.kr > 0)
+  const tilgjengeligProsent = (tilgjengeligKr / beløp) * 100
 
   return (
-    // The bar is always full-width. Colored segments take their share,
-    // and the grey remainder segment (flex-1) fills whatever is left —
-    // this works for all cases: fully allocated, partially allocated, and
-    // float over-allocation (flex naturally clamps the remainder to 0).
     <div className="flex h-7 w-full overflow-hidden rounded-lg">
       {synlige.map((k, i) => {
+        const bredde = (k.kr / beløp) * 100
         const erFørste = i === 0
-        // Round only for display — internal prosent stays float for kr precision
-        const prosDisplay = Math.round(k.prosent)
-        const visLabel = k.prosent >= 8
+        const visLabel = bredde >= 8
 
         return (
           <div
             key={k.id}
-            className="relative flex items-center justify-center overflow-hidden transition-all duration-200"
+            className="relative flex items-center justify-center overflow-hidden transition-all duration-150"
             style={{
-              width: `${k.prosent}%`,
+              width: `${bredde}%`,
               backgroundColor: k.farge,
               borderRadius: erFørste ? "0.5rem 0 0 0.5rem" : undefined,
             }}
-            title={`${k.navn || "Uten navn"} — ${prosDisplay}%`}
+            title={`${k.navn || "Uten navn"} — ${formatKr(k.kr)}`}
           >
             {visLabel && (
               <span className="truncate px-1 text-[10px] font-semibold text-white/90">
-                {prosDisplay}%
+                {Math.round(bredde)}%
               </span>
             )}
           </div>
         )
       })}
 
-      {/* Grey remainder — flex-1 so it always fills the remaining width.
-          Label rules: >= 25% segment AND sm: breakpoint → full text;
-          >= 5% segment → "?" (fits a single char); < 5% → no label. */}
+      {/* Grey remainder — represents unallocated funds */}
       <div
-        className="flex-1 flex items-center justify-center overflow-hidden bg-muted transition-all duration-200"
+        className="flex-1 flex items-center justify-center overflow-hidden bg-muted transition-all duration-150"
         style={{
           borderRadius: synlige.length === 0 ? "0.5rem" : "0 0.5rem 0.5rem 0",
         }}
-        title={ufordeltKr > 0 ? `${formatKr(ufordeltKr)} gjenstår` : undefined}
+        title={tilgjengeligKr > 0 ? `${formatKr(tilgjengeligKr)} gjenstår` : undefined}
       >
-        {ufordeltProsent >= 5 && (
+        {tilgjengeligProsent >= 5 && (
           <span className="truncate px-1 text-[10px] font-semibold text-foreground/50">
-            {/* Full text: only when segment is wide (>= 25%) AND screen is sm+ */}
-            {ufordeltProsent >= 25 && (
-              <span className="hidden sm:inline">{formatKr(ufordeltKr)} gjenstår</span>
+            {tilgjengeligProsent >= 25 && (
+              <span className="hidden sm:inline">{formatKr(tilgjengeligKr)} gjenstår</span>
             )}
-            {/* Question mark: fallback when full text is hidden */}
-            <span className={ufordeltProsent >= 25 ? "sm:hidden" : ""}>?</span>
+            <span className={tilgjengeligProsent >= 25 ? "sm:hidden" : ""}>?</span>
           </span>
         )}
       </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pedagogical available-funds display
+// ---------------------------------------------------------------------------
+
+interface TilgjengeligDisplayProps {
+  tilgjengeligKr: number
+  beløp: number
+}
+
+function TilgjengeligDisplay({ tilgjengeligKr, beløp }: TilgjengeligDisplayProps) {
+  const altFordelt = tilgjengeligKr === 0
+
+  if (altFordelt) {
+    return (
+      <div className="flex items-center gap-2.5 rounded-lg bg-[oklch(0.62_0.15_140)]/10 px-4 py-3">
+        <CheckCircle size={18} className="shrink-0 text-[oklch(0.62_0.15_140)]" />
+        <div>
+          <p className="text-sm font-medium text-foreground">Alt er fordelt</p>
+          <p className="text-xs text-muted-foreground">
+            Du har fordelt alle {formatKr(beløp)}.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-between rounded-lg bg-muted/50 px-4 py-3">
+      <p className="text-sm text-muted-foreground">Gjenstår å fordele</p>
+      <p className="text-lg font-bold tabular-nums text-foreground">{formatKr(tilgjengeligKr)}</p>
     </div>
   )
 }
@@ -96,8 +125,8 @@ function FordelingsBar({ kategorier, ufordeltKr }: FordelingsBarProps) {
 interface KategoriRadProps {
   kategori: UventetSumKategori
   beløp: number
-  onEndreProsent: (id: string, prosent: number) => void
-  onLåsOpp: (id: string) => void
+  tilgjengeligKr: number
+  onEndreKr: (id: string, kr: number) => void
   onEndreNavn: (id: string, navn: string) => void
   onFjern: (id: string) => void
   kanFjernes: boolean
@@ -106,52 +135,36 @@ interface KategoriRadProps {
 function KategoriRad({
   kategori,
   beløp,
-  onEndreProsent,
-  onLåsOpp,
+  tilgjengeligKr,
+  onEndreKr,
   onEndreNavn,
   onFjern,
   kanFjernes,
 }: KategoriRadProps) {
-  const harBeløp = beløp > 0
-  const krVerdi = Math.round(beløp * kategori.prosent / 100)
-  // step=1 so the slider can hit any exact kr value; precision typing is available via click-to-edit
-
-  // Inline editing of the kr value — clicking the number opens a text input
   const [redigerer, setRedigerer] = useState(false)
   const [draft, setDraft] = useState("")
   const redigerInputRef = useRef<HTMLInputElement>(null)
 
   function startRedigering() {
-    if (!harBeløp) return
-    setDraft(String(krVerdi))
+    setDraft(String(kategori.kr))
     setRedigerer(true)
-    // Let the input mount before selecting its content
     setTimeout(() => redigerInputRef.current?.select(), 0)
   }
 
   function commitRedigering() {
     const parsed = parseInt(draft.replace(/\s/g, "").replace(/,/g, ""), 10)
-    if (!isNaN(parsed) && parsed >= 0 && beløp > 0) {
-      const nyProsent = Math.min(parsed, beløp) / beløp * 100
-      onEndreProsent(kategori.id, nyProsent)
+    if (!isNaN(parsed) && parsed >= 0) {
+      onEndreKr(kategori.id, avrundTilNærmeste100(Math.min(parsed, beløp)))
     }
     setRedigerer(false)
   }
 
-  // Convert a kr slider value to a float percent and dispatch.
-  // Keeping full float precision means Math.round(beløp * prosent / 100)
-  // recovers the exact dragged kr value rather than snapping to beløp/100 steps.
-  function handleSliderChange(krNy: number) {
-    if (harBeløp) {
-      onEndreProsent(kategori.id, krNy / beløp * 100)
-    } else {
-      onEndreProsent(kategori.id, krNy)
-    }
-  }
+  // Max this slider can reach: current allocation + what's still free
+  const sliderMax = Math.max(kategori.kr + tilgjengeligKr, kategori.kr)
 
   return (
     <div className="space-y-2">
-      {/* Header: color dot + name input + action buttons */}
+      {/* Header: color dot + name input + delete button */}
       <div className="flex items-center gap-2">
         <div
           className="h-3 w-3 shrink-0 rounded-full"
@@ -166,33 +179,20 @@ function KategoriRad({
           className="min-w-0 flex-1 bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground/60"
           aria-label="Kategorinavn"
         />
-        <div className="flex shrink-0 items-center gap-1">
-          {kategori.locked && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => onLåsOpp(kategori.id)}
-              className="h-7 gap-1 px-2 text-xs text-muted-foreground"
-            >
-              <LockOpenIcon size={12} />
-              Lås opp
-            </Button>
-          )}
-          {kanFjernes && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => onFjern(kategori.id)}
-              className="h-7 w-7 text-muted-foreground hover:text-destructive"
-              aria-label={`Fjern ${kategori.navn || "kategori"}`}
-            >
-              <TrashIcon size={14} />
-            </Button>
-          )}
-        </div>
+        {kanFjernes && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onFjern(kategori.id)}
+            className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+            aria-label={`Fjern ${kategori.navn || "kategori"}`}
+          >
+            <TrashIcon size={14} />
+          </Button>
+        )}
       </div>
 
-      {/* Editable value — click to type an exact kr amount */}
+      {/* Editable kr value */}
       {redigerer ? (
         <div className="relative inline-flex items-baseline gap-1">
           <input
@@ -203,8 +203,6 @@ function KategoriRad({
             onChange={(e) => setDraft(e.target.value)}
             onBlur={commitRedigering}
             onKeyDown={(e) => {
-              // Trigger blur on Enter so onBlur handles the single commit path —
-              // avoids double-calling commitRedigering (which would re-redistribute)
               if (e.key === "Enter") e.currentTarget.blur()
               if (e.key === "Escape") setRedigerer(false)
             }}
@@ -215,33 +213,28 @@ function KategoriRad({
         </div>
       ) : (
         <button
-          onClick={harBeløp ? startRedigering : undefined}
-          className={[
-            "text-xl font-bold tabular-nums text-left",
-            harBeløp
-              ? "cursor-text text-foreground hover:text-primary transition-colors"
-              : "cursor-default text-foreground",
-          ].join(" ")}
-          title={harBeløp ? "Klikk for å skrive inn et eksakt beløp" : undefined}
+          onClick={startRedigering}
+          className="text-xl font-bold tabular-nums text-left cursor-text text-foreground hover:text-primary transition-colors"
+          title="Klikk for å skrive inn et eksakt beløp"
         >
-          {harBeløp ? formatKr(krVerdi) : `${kategori.prosent}%`}
+          {formatKr(kategori.kr)}
         </button>
       )}
 
-      {/* Kr-based slider (step adapts to amount for clean increments) */}
+      {/* Slider — step=100 for clean increments, max capped at what's available */}
       <Slider
-        value={[harBeløp ? krVerdi : kategori.prosent]}
+        value={[kategori.kr]}
         min={0}
-        max={harBeløp ? beløp : 100}
-        step={1}
-        onValueChange={([v]) => handleSliderChange(v)}
+        max={sliderMax || beløp}
+        step={100}
+        onValueChange={([v]) => onEndreKr(kategori.id, v)}
         aria-label={`Fordeling for ${kategori.navn || "kategori"}`}
       />
 
       {/* Slider end labels */}
       <div className="flex justify-between text-xs text-muted-foreground">
-        <span>{harBeløp ? "0 kr" : "0%"}</span>
-        <span>{harBeløp ? formatKr(beløp) : "100%"}</span>
+        <span>0 kr</span>
+        <span>{formatKr(beløp)}</span>
       </div>
     </div>
   )
@@ -255,33 +248,27 @@ export function UventetSumApp() {
   const {
     state,
     setBeløp,
-    endreProsent,
-    låsOpp,
+    endreKr,
     endreNavn,
     leggTilKategori,
     fjernKategori,
     nullstillFordeling,
   } = useUventetSumState()
 
-  // Draft string for the beløp input — only commits on blur/Enter
   const [beløpDraft, setBeløpDraft] = useState(
     state.beløp > 0 ? String(state.beløp) : ""
   )
 
   const harBeløp = state.beløp > 0
 
-  // Kr remaining after all categories are allocated. Uses Math.round per category so
-  // the result matches what the user sees in the summary (same rounding as display).
-  const fordeltKr = state.kategorier.reduce(
-    (s, k) => s + Math.round(state.beløp * k.prosent / 100),
-    0
-  )
-  const ufordeltKr = state.beløp - fordeltKr
+  const fordeltKr = state.kategorier.reduce((s, k) => s + k.kr, 0)
+  const tilgjengeligKr = state.beløp - fordeltKr
 
   function commitBeløp(raw: string) {
     const parsed = parseBeløp(raw)
-    setBeløp(parsed)
-    setBeløpDraft(parsed > 0 ? String(parsed) : "")
+    const rundet = parsed > 0 ? avrundTilNærmeste100(parsed) : 0
+    setBeløp(rundet)
+    setBeløpDraft(rundet > 0 ? String(rundet) : "")
   }
 
   return (
@@ -296,8 +283,8 @@ export function UventetSumApp() {
           Fått inn en uventet sum?
         </h1>
         <p className="text-sm leading-relaxed text-muted-foreground">
-          Fordel beløpet mellom kategorier. Dra en slider for å låse den — de andre
-          tilpasser seg automatisk.
+          Fordel beløpet mellom kategorier. Dra en slider for å velge hvor mye som
+          går til hvert formål — totalen kan ikke overgå det du har fått inn.
         </p>
       </div>
 
@@ -306,7 +293,6 @@ export function UventetSumApp() {
         <label htmlFor="beløp-input" className="text-sm font-medium">
           Hvor mye har du fått?
         </label>
-        {/* Input + button inline — button stays visible for re-running with a new amount */}
         <div className="flex items-center gap-2">
           <div className="relative w-40 sm:w-48">
             <Input
@@ -334,20 +320,29 @@ export function UventetSumApp() {
             onClick={() => commitBeløp(beløpDraft)}
             disabled={parseBeløp(beløpDraft) === 0}
           >
-            Se fordeling
+            Start fordeling
             <ArrowRightIcon data-icon="inline-end" />
           </Button>
         </div>
+        <p className="text-xs text-muted-foreground">
+          Vi avrunder til nærmeste 100 kr for ryddigere beløp.
+        </p>
       </div>
 
       {/* Distribution section — only visible once an amount is entered */}
       {harBeløp && (
         <div className="space-y-8">
 
-          {/* Distribution bar + reset — reset lives here so it's close to
-              the thing it affects and doesn't require scrolling past all sliders */}
+          {/* Available-funds display */}
+          <TilgjengeligDisplay tilgjengeligKr={tilgjengeligKr} beløp={state.beløp} />
+
+          {/* Distribution bar + reset */}
           <div className="space-y-2">
-            <FordelingsBar kategorier={state.kategorier} ufordeltKr={ufordeltKr} />
+            <FordelingsBar
+              kategorier={state.kategorier}
+              beløp={state.beløp}
+              tilgjengeligKr={tilgjengeligKr}
+            />
             <Button
               variant="outline"
               size="sm"
@@ -359,17 +354,6 @@ export function UventetSumApp() {
             </Button>
           </div>
 
-          {/* Alert: shown only when there are unallocated kr */}
-          {ufordeltKr > 0 && (
-            <Alert>
-              <WarningIcon size={16} />
-              <AlertTitle>{formatKr(ufordeltKr)} er ikke fordelt ennå.</AlertTitle>
-              <AlertDescription>
-                Lås opp en kategori eller juster en slider for å fordele resten.
-              </AlertDescription>
-            </Alert>
-          )}
-
           {/* Category sliders */}
           <div className="space-y-6">
             {state.kategorier.map((kat) => (
@@ -377,8 +361,8 @@ export function UventetSumApp() {
                 key={kat.id}
                 kategori={kat}
                 beløp={state.beløp}
-                onEndreProsent={endreProsent}
-                onLåsOpp={låsOpp}
+                tilgjengeligKr={tilgjengeligKr}
+                onEndreKr={endreKr}
                 onEndreNavn={endreNavn}
                 onFjern={fjernKategori}
                 kanFjernes={state.kategorier.length > 1}
@@ -408,7 +392,7 @@ export function UventetSumApp() {
             </p>
             <div className="space-y-2">
               {state.kategorier
-                .filter((k) => k.prosent > 0)
+                .filter((k) => k.kr > 0)
                 .map((k) => (
                   <div key={k.id} className="flex items-center justify-between">
                     <div className="flex items-center gap-2 text-sm">
@@ -419,21 +403,18 @@ export function UventetSumApp() {
                       />
                       <span className="text-foreground">{k.navn || "Uten navn"}</span>
                     </div>
-                    <span className="tabular-nums text-sm font-medium">
-                      {formatKr(Math.round(state.beløp * k.prosent / 100))}
-                    </span>
+                    <span className="tabular-nums text-sm font-medium">{formatKr(k.kr)}</span>
                   </div>
                 ))}
             </div>
-            {/* Unallocated row — only shown when kr remain */}
-            {ufordeltKr > 0 && (
+            {tilgjengeligKr > 0 && (
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 text-sm">
                   <div className="h-2.5 w-2.5 shrink-0 rounded-full bg-muted-foreground/30" aria-hidden />
                   <span className="text-muted-foreground">Ikke fordelt</span>
                 </div>
                 <span className="tabular-nums text-sm font-medium text-muted-foreground">
-                  {formatKr(ufordeltKr)}
+                  {formatKr(tilgjengeligKr)}
                 </span>
               </div>
             )}

--- a/src/hooks/useUventetSumState.ts
+++ b/src/hooks/useUventetSumState.ts
@@ -7,47 +7,7 @@ import {
   saveUventetSumState,
 } from "@/lib/uventet-sum-storage"
 
-// ---------------------------------------------------------------------------
-// Redistribution logic
-// ---------------------------------------------------------------------------
-
-/**
- * When the user drags a slider, that category is auto-locked. Only unlocked
- * categories absorb the change, proportionally to their current share.
- */
-function normaliserProsenter(
-  kategorier: UventetSumKategori[],
-  endretId: string,
-  nyProsent: number
-): UventetSumKategori[] {
-  const låsteAndre = kategorier.filter((k) => k.id !== endretId && k.locked)
-  const frie = kategorier.filter((k) => k.id !== endretId && !k.locked)
-
-  const låstTotal = låsteAndre.reduce((s, k) => s + k.prosent, 0)
-  // Cap: the changed category cannot exceed what's left after locked others
-  const faktiskProsent = Math.min(nyProsent, 100 - låstTotal)
-  const gjenværende = 100 - låstTotal - faktiskProsent
-
-  const friTotal = frie.reduce((s, k) => s + k.prosent, 0)
-
-  return kategorier.map((k) => {
-    if (k.id === endretId) return { ...k, prosent: faktiskProsent, locked: true }
-    if (k.locked) return k
-    if (frie.length === 0) return k
-    // Keep prosent as float — rounding to integer here causes kr snap-to-340 jumps
-    // (for e.g. 34 000 kr, 1% = 340 kr, so integer prosent = 340 kr minimum step).
-    // Display code rounds for labels; Math.round(beløp * prosent / 100) recovers exact kr.
-    if (friTotal === 0) return { ...k, prosent: gjenværende / frie.length }
-    return { ...k, prosent: gjenværende * (k.prosent / friTotal) }
-  })
-}
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
 function lagInitialState(): UventetSumState {
-  // SSR guard: localStorage is only available in the browser
   if (typeof window === "undefined") {
     return { beløp: 0, kategorier: klonaKategorier() }
   }
@@ -57,29 +17,32 @@ function lagInitialState(): UventetSumState {
 export function useUventetSumState() {
   const [state, setState] = useState<UventetSumState>(lagInitialState)
 
-  // Persist on every state change
   useEffect(() => {
     saveUventetSumState(state)
   }, [state])
 
+  // Entering a new amount resets all categories to 0 kr
   const setBeløp = useCallback((beløp: number) => {
-    setState((prev) => ({ ...prev, beløp }))
-  }, [])
-
-  const endreProsent = useCallback((id: string, nyProsent: number) => {
     setState((prev) => ({
-      ...prev,
-      kategorier: normaliserProsenter(prev.kategorier, id, nyProsent),
+      beløp,
+      kategorier: prev.kategorier.map((k) => ({ ...k, kr: 0 })),
     }))
   }, [])
 
-  const låsOpp = useCallback((id: string) => {
-    setState((prev) => ({
-      ...prev,
-      kategorier: prev.kategorier.map((k) =>
-        k.id === id ? { ...k, locked: false } : k
-      ),
-    }))
+  // Set kr for a category — capped so the total never exceeds beløp
+  const endreKr = useCallback((id: string, nyKr: number) => {
+    setState((prev) => {
+      const andreKr = prev.kategorier
+        .filter((k) => k.id !== id)
+        .reduce((s, k) => s + k.kr, 0)
+      const klampetKr = Math.max(0, Math.min(nyKr, prev.beløp - andreKr))
+      return {
+        ...prev,
+        kategorier: prev.kategorier.map((k) =>
+          k.id === id ? { ...k, kr: klampetKr } : k
+        ),
+      }
+    })
   }, [])
 
   const endreNavn = useCallback((id: string, navn: string) => {
@@ -94,8 +57,7 @@ export function useUventetSumState() {
       const nyKategori: UventetSumKategori = {
         id: Math.random().toString(36).slice(2, 9),
         navn: "",
-        prosent: 0,
-        locked: false,
+        kr: 0,
         farge: nyttFargeFraPaletten(prev.kategorier.length),
       }
       return { ...prev, kategorier: [...prev.kategorier, nyKategori] }
@@ -106,22 +68,11 @@ export function useUventetSumState() {
     setState((prev) => {
       const gjenværende = prev.kategorier.filter((k) => k.id !== id)
       if (gjenværende.length === 0) return prev
-
-      // After structural change (remove): reset all locks and redistribute
-      // the removed category's share proportionally among survivors.
-      const total = gjenværende.reduce((s, k) => s + k.prosent, 0)
-      const justerte = gjenværende.map((k) => ({
-        ...k,
-        locked: false,
-        prosent:
-          total === 0
-            ? Math.round(100 / gjenværende.length)
-            : Math.round(k.prosent * (100 / total)),
-      }))
-      return { ...prev, kategorier: justerte }
+      return { ...prev, kategorier: gjenværende }
     })
   }, [])
 
+  // Resets to default categories with 0 kr each
   const nullstillFordeling = useCallback(() => {
     setState((prev) => ({ ...prev, kategorier: klonaKategorier() }))
   }, [])
@@ -129,8 +80,7 @@ export function useUventetSumState() {
   return {
     state,
     setBeløp,
-    endreProsent,
-    låsOpp,
+    endreKr,
     endreNavn,
     leggTilKategori,
     fjernKategori,

--- a/src/lib/uventet-sum-storage.ts
+++ b/src/lib/uventet-sum-storage.ts
@@ -3,25 +3,24 @@ import type { UventetSumKategori, UventetSumState } from "@/types/uventet-sum"
 const STORAGE_KEY = "pengeprat_uventet_sum"
 
 // Colors match src/lib/kategorier.ts and SparemaalApp.tsx (FARGE constant)
-// for visual consistency across the app. Framtidsfri uses the same violet as
-// in Definer taket. The extra blue covers user-added categories.
+// for visual consistency across the app.
 const FARGER = [
   "oklch(0.62 0.15 185)", // buffer             — teal
   "oklch(0.65 0.14 70)",  // guiltFree          — amber
   "oklch(0.63 0.15 30)",  // ferie              — orange
   "oklch(0.53 0.19 295)", // storeLivshendelser — purple
   "oklch(0.62 0.15 140)", // pensjon            — green
-  "oklch(0.61 0.19 278)", // framtidsfri        — violet (matches SparemaalApp)
+  "oklch(0.61 0.19 278)", // framtidsfri        — violet
   "oklch(0.58 0.16 250)", // extra              — blue
 ]
 
 export const DEFAULT_KATEGORIER: UventetSumKategori[] = [
-  { id: "buffer",             navn: "Buffer",              prosent: 20, locked: false, farge: FARGER[0] },
-  { id: "guiltFree",          navn: "Guilt-free spending", prosent: 15, locked: false, farge: FARGER[1] },
-  { id: "ferie",              navn: "Ferie",               prosent: 15, locked: false, farge: FARGER[2] },
-  { id: "storeLivshendelser", navn: "Store livshendelser", prosent: 15, locked: false, farge: FARGER[3] },
-  { id: "framtidsfri",        navn: "Framtidsfri",         prosent: 20, locked: false, farge: FARGER[5] },
-  { id: "pensjon",            navn: "Pensjon",             prosent: 15, locked: false, farge: FARGER[4] },
+  { id: "buffer",             navn: "Buffer",              kr: 0, farge: FARGER[0] },
+  { id: "guiltFree",          navn: "Guilt-free spending", kr: 0, farge: FARGER[1] },
+  { id: "ferie",              navn: "Ferie",               kr: 0, farge: FARGER[2] },
+  { id: "storeLivshendelser", navn: "Store livshendelser", kr: 0, farge: FARGER[3] },
+  { id: "framtidsfri",        navn: "Framtidsfri",         kr: 0, farge: FARGER[5] },
+  { id: "pensjon",            navn: "Pensjon",             kr: 0, farge: FARGER[4] },
 ]
 
 export function nyttFargeFraPaletten(antallEksisterende: number): string {
@@ -37,9 +36,9 @@ export function loadUventetSumState(): UventetSumState {
     const lagret = localStorage.getItem(STORAGE_KEY)
     if (lagret) {
       const data = JSON.parse(lagret) as UventetSumState
-      // Migration: ensure all saved categories have the locked field
-      if (data.kategorier) {
-        data.kategorier = data.kategorier.map((k) => ({ locked: false, ...k }))
+      // Migration: old format used prosent+locked instead of kr — reset to defaults
+      if (data.kategorier?.[0] && "prosent" in (data.kategorier[0] as Record<string, unknown>)) {
+        return { beløp: 0, kategorier: klonaKategorier() }
       }
       return data
     }

--- a/src/types/uventet-sum.ts
+++ b/src/types/uventet-sum.ts
@@ -1,10 +1,8 @@
 export interface UventetSumKategori {
   id: string
   navn: string
-  /** Percentage allocation (0–100). Sum across all categories should equal 100. */
-  prosent: number
-  /** When true this category is pinned and excluded from auto-redistribution. */
-  locked: boolean
+  /** Kr allocated to this category (0 to state.beløp). */
+  kr: number
   farge: string
 }
 


### PR DESCRIPTION
## Hva er endret

Komplett redesign av tilnærmingen i Uventet sum-verktøyet.

### Ny flyt
- **Start fra null** — alle kategorier begynner på 0 kr i stedet for forhåndsfordelte prosenter
- **Bygg opp selv** — brukeren drar slidere for å velge beløp per formål
- **Tak = beløpet du tastet inn** — summen av alle sliders kan aldri overgå det innfylte beløpet

### Avrunding til nærmeste 100 kr
- Slider-steg er nå 100 kr (ikke 1 kr) — fjerner unødvendig detaljnivå og gir bedre ytelse
- Beløpet som tastes inn rundes automatisk til nærmeste 100 kr
- Liten hjelpetekst under input: *"Vi avrunder til nærmeste 100 kr for ryddigere beløp"*

### Pedagogisk saldovisning (erstatter varselet)
- Fjernet `Alert` med `WarningIcon` om ufordelte kroner
- Ny `TilgjengeligDisplay`-komponent øverst i fordelingseksjonen viser rolig *"Gjenstår å fordele — X kr"*
- Når alt er fordelt skifter den til en grønn *"Alt er fordelt"*-bekreftelse

### Teknisk
- Datamodell forenklet: `prosent`/`locked` erstattet med direkte `kr` per kategori
- Hele auto-redistribusjons- og låselogikken er fjernet
- Gammel localStorage-data migreres automatisk ved å nullstille til defaults

## Berørte filer
- `src/types/uventet-sum.ts`
- `src/lib/uventet-sum-storage.ts`
- `src/hooks/useUventetSumState.ts`
- `src/components/uventet-sum/UventetSumApp.tsx`

https://claude.ai/code/session_01889ZhZx37nD8CKv28rrEVz