### PR TITLE
Fix mobile slider swipe conflict and nav overflow

### DIFF
--- a/src/components/fordeling/FordelingTabell.tsx
+++ b/src/components/fordeling/FordelingTabell.tsx
@@ -127,7 +127,7 @@ function MobileEkspansjon({
   const max = sliderMax(lønn, kat.sliderMaxFaktor ?? 0.2)
 
   return (
-    <div className="px-4 pb-4 space-y-4 border-t border-border">
+    <div className="px-6 pb-4 space-y-4 border-t border-border">
       {kat.inputType === "tekst" ? (
         <div className="pt-3 space-y-1.5">
           <label className="text-sm font-medium">Månedlige faste utgifter</label>

--- a/src/layouts/app.astro
+++ b/src/layouts/app.astro
@@ -48,19 +48,19 @@ function erAktiv(href: string) {
 
     <!-- Top nav -->
     <header class="sticky top-0 z-10 border-b border-border bg-card">
-      <div class="mx-auto flex h-14 max-w-5xl items-center justify-between px-4 sm:px-6">
+      <div class="mx-auto flex h-14 max-w-5xl items-center gap-2 px-4 sm:px-6">
         <a
           href="/"
-          class="text-sm font-semibold tracking-tight text-foreground hover:text-primary transition-colors"
+          class="shrink-0 text-sm font-semibold tracking-tight text-foreground hover:text-primary transition-colors"
         >
           Pengeprat
         </a>
-        <nav class="flex items-center gap-1">
+        <nav class="flex-1 min-w-0 flex items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {verktøy.map((v) => (
             <a
               href={v.href}
               class:list={[
-                "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                "shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
                 erAktiv(v.href)
                   ? "bg-muted text-foreground"
                   : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
@@ -69,8 +69,10 @@ function erAktiv(href: string) {
               {v.label}
             </a>
           ))}
-          <ModeToggle client:load />
         </nav>
+        <div class="shrink-0">
+          <ModeToggle client:load />
+        </div>
       </div>
     </header>
 


### PR DESCRIPTION
## Hva og hvorfor

To relaterte mobilfeil funnet under testing på ulike skjermstørrelser.

### 1. Slider vs. iOS swipe-back-gest (`FordelingTabell.tsx`)

Slideren i den innebygde mobil-ekspansjonen kunne kræsje med nettleserens «swipe left-to-right to go back»-gest.

**Rotårsak:** Slider-track startet 37px fra venstrekanten. Slider-thumben ved minimumsverdien (50 kr) strakk seg fra ~29px — inn i iOS Safaris ~30px-sone der nettleseren intercepter back-gesten på OS-nivå, før `touchstart` når siden.

**Fix:** `px-4` → `px-6` i `MobileEkspansjon`, som skyver track til 45px og thumb-minimum til 37px.

| | Før | Etter |
|---|---|---|
| Track start | 37px | 45px |
| Thumb ved min | ~29px ⚠ | ~37px ✓ |

### 2. Blank stripe til høyre + ModeToggle utenfor viewport (`app.astro`)

**Rotårsak:** `astro-island` bruker `display: contents`, som gjør at ModeToggle-knappen (36px) deltok direkte i nav-flexlayouten. Med for mange nav-lenker ble knappen presset til `left: 390px` på en 390px-skjerm — helt utenfor viewport. `body` ekspanderte til 426px mens `main` bare var 390px, noe som skapte en 36px bred blank stripe til høyre.

**Fix:** ModeToggle flyttes ut av `<nav>` og inn i sin egen `shrink-0`-wrapper. Nav blir `flex-1 min-w-0 overflow-x-auto` med skjult scrollbar og `shrink-0` på hvert lenke-element.

- ModeToggle alltid synlig, uavhengig av skjermbredde
- Nav scroller horisontalt på smale skjermer (320–375px)
- Ingen synlig scrollbar
- Ingen overflow i body

## Testing

- [x] Verifisert i preview på 320px, 375px, 390px og desktop
- [ ] Bør testes på ekte iOS-enhet via Vercel preview-URL for å bekrefte at slider-thumben ikke trigget back-gest lenger